### PR TITLE
add wait_tx_result to aergo api

### DIFF
--- a/aergo/herapy/aergo.py
+++ b/aergo/herapy/aergo.py
@@ -3,6 +3,7 @@
 """Main module."""
 
 import json
+import time
 
 from . import account as acc
 from . import comm
@@ -710,6 +711,23 @@ class Aergo:
 
         return tx_result
 
+    def wait_tx_result(self, tx_hash, timeout=30, tempo=0.2):
+        if self.__comm is None:
+            return None
+        if isinstance(tx_hash, str):
+            tx_hash = decode_tx_hash(tx_hash)
+        elif type(tx_hash) is th.TxHash:
+            tx_hash = bytes(tx_hash)
+
+        for _ in range(int(timeout/tempo)):
+            try:
+                return self.get_tx_result(tx_hash)
+            except CommunicationException as e:
+                if e.error_details is None or e.error_details[:12] != "tx not found":
+                    raise e
+            time.sleep(tempo)
+        return None
+            
     def deploy_sc(self, payload, amount=0, args=None, retry_nonce=0):
         if isinstance(payload, str):
             payload = decode_address(payload)

--- a/aergo/herapy/aergo.py
+++ b/aergo/herapy/aergo.py
@@ -719,7 +719,7 @@ class Aergo:
         elif type(tx_hash) is th.TxHash:
             tx_hash = bytes(tx_hash)
 
-        for _ in range(int(timeout/tempo)):
+        for _ in range(int(timeout/tempo)+1):
             try:
                 return self.get_tx_result(tx_hash)
             except CommunicationException as e:

--- a/examples/smartcontract.py
+++ b/examples/smartcontract.py
@@ -112,7 +112,13 @@ def run():
         print("------ Call SC -----------")
         tx, result = aergo.call_sc(sc_address, "test_array", args=[["a", "b"]])
 
-        time.sleep(3)
+        print("-------Wait for tx result--------")
+        result = aergo.wait_tx_result(tx.tx_hash)
+        if result.status != herapy.TxResultStatus.SUCCESS:
+            eprint("  > ERROR[{0}]:{1}: {2}".format(
+                result.contract_address, result.status, result.detail))
+            aergo.disconnect()
+            return
 
         print("------ Check result of Call SC -----------")
         print("  > TX: {}".format(tx.tx_hash))


### PR DESCRIPTION
`wait_tx_result` returns the result (before a timeout) when the tx has been executed and the result is available. 
Users don't need to wait a fixed amount of time before getting the tx result (network can be slow to include tx in block and 'tx not found' exception would be raised). Waiting for the tx result solves this.
