### PR TITLE
add keystore v1 support

### DIFF
--- a/aergo/herapy/aergo.py
+++ b/aergo/herapy/aergo.py
@@ -770,12 +770,30 @@ class Aergo:
                 self.get_account(account=account)
         return account
 
+    def import_account_from_keystore(self, keystore, password, skip_state=False, skip_self=False):
+        account = acc.Account.decrypt_from_keystore(keystore, password)
+        if not skip_self:
+            self.__account = account
+            if not skip_state:
+                self.get_account()
+        else:
+            if not skip_state:
+                self.get_account(account=account)
+        return account
+
     def export_account(self, password, account=None):
         if account is None:
             account = self.__account
 
         enc_acc = acc.Account.encrypt_account(account, password)
         return encode_private_key(enc_acc)
+
+    def export_account_to_keystore(self, password, account=None, kdf_n=2**18):
+        if account is None:
+            account = self.__account
+
+        keystore = acc.Account.encrypt_to_keystore(account, password, kdf_n)
+        return keystore
 
     def get_tx_result(self, tx_hash):
         if self.__comm is None:

--- a/aergo/herapy/obj/private_key.py
+++ b/aergo/herapy/obj/private_key.py
@@ -7,7 +7,7 @@ from ecdsa.util import string_to_number
 
 from .address import Address
 
-from ..utils.converter import encrypt_bytes, decrypt_bytes
+from ..utils.encryption import encrypt_bytes, decrypt_bytes
 from ..utils.encoding import encode_private_key, decode_private_key, \
     encode_b58, decode_b58
 from ..utils.signature import deserialize_sig, serialize_sig

--- a/aergo/herapy/utils/encryption.py
+++ b/aergo/herapy/utils/encryption.py
@@ -1,0 +1,180 @@
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.ciphers.modes import CTR
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+from cryptography.hazmat.backends import default_backend
+import hashlib
+import os
+import copy
+
+from .converter import (
+    privkey_to_address
+)
+
+
+KEYSTORE_V1 = {
+    "aergo_address": "",
+    "ks_version": "1",
+    "cipher": {
+        "algorithm": "aes-128-ctr",
+        "params": {
+            "iv": ""
+        },
+        "ciphertext": ""
+    },
+    "kdf": {
+        "algorithm": "scrypt",
+        "params": {
+            "dklen": 32,
+            "n": 262144,
+            "p": 1,
+            "r": 8,
+            "salt": ""
+        },
+        "mac": ""
+    }
+}
+
+
+def decrypt_keystore_v1(keystore, password):
+    # check version and algorithm names
+    assert keystore['ks_version'] == \
+        KEYSTORE_V1['ks_version'], "Invalid keystore version"
+
+    assert keystore['cipher']['algorithm'] == \
+        KEYSTORE_V1['cipher']['algorithm'], "Invalid cipher algorithm"
+
+    assert keystore['kdf']['algorithm'] == \
+        KEYSTORE_V1['kdf']['algorithm'], "Invalid kdf algorithm"
+
+    ct = bytes.fromhex(keystore['cipher']['ciphertext'])
+
+    # derive cipher_key (used to decrypt cipher text) from password
+    backend = default_backend()
+    kdf_params = keystore['kdf']['params']
+    cipher_key = derive_cipher_key(
+        bytes.fromhex(kdf_params['salt']),
+        kdf_params['dklen'],
+        kdf_params['n'],
+        kdf_params['r'],
+        kdf_params['p'],
+        backend,
+        password
+    )
+
+    # check mac to make sure the cipher key is correct
+    mac = hashlib.sha256(cipher_key[16:32] + ct).digest().hex()
+    assert mac == keystore['kdf']['mac'], "Failed to verify mac"
+
+    # decrypt cipher text to get private key bytes
+    iv = bytes.fromhex(keystore['cipher']['params']['iv'])
+    cipher = Cipher(AES(cipher_key[:16]), CTR(iv), backend=backend)
+    decryptor = cipher.decryptor()
+    privkey_raw = decryptor.update(ct) + decryptor.finalize()
+
+    # check address matches private key
+    address = privkey_to_address(privkey_raw)
+    assert address == keystore['aergo_address'], "Failed to verify address"
+
+    return privkey_raw
+
+
+def encrypt_to_keystore_v1(privkey, address, password, kdf_n=2**18):
+    assert address == \
+        privkey_to_address(privkey), "address doesn't match privkey"
+    backend = default_backend()
+
+    # create random cipher_key (derived from password) to encrypt
+    salt = os.urandom(16)
+    cipher_key = derive_cipher_key(
+        salt,
+        32,
+        kdf_n,
+        8,  # RFC 7914 recommendation
+        1,  # RFC 7914 recommendation
+        backend, password
+    )
+
+    # encrypt privkey
+    iv = os.urandom(16)
+    cipher = Cipher(AES(cipher_key[:16]), CTR(iv), backend=backend)
+    encryptor = cipher.encryptor()
+    ct = encryptor.update(privkey) + encryptor.finalize()
+
+    # calculate mac
+    mac = hashlib.sha256(cipher_key[16:32] + ct).digest().hex()
+
+    # create keystore dictionary (json)
+    keystore = copy.deepcopy(KEYSTORE_V1)
+    keystore['cipher']['params']['iv'] = iv.hex()
+    keystore['cipher']['ciphertext'] = ct.hex()
+    keystore['kdf']['params']['n'] = kdf_n
+    keystore['kdf']['params']['salt'] = salt.hex()
+    keystore['kdf']['mac'] = mac
+    keystore['aergo_address'] = address
+    return keystore
+
+
+def derive_cipher_key(salt, l, n, r, p, backend, password):
+    kdf = Scrypt(
+        salt=salt,
+        length=l,
+        n=n,
+        r=r,
+        p=p,
+        backend=backend
+    )
+    return kdf.derive(password.encode())
+
+
+def encrypt_bytes(data, password):
+    """
+    https://cryptography.io/en/latest/hazmat/primitives/aead/
+    :param data: bytes to encrypt
+    :return: encrypted  data (bytes)
+    """
+    if isinstance(password, str):
+        password = bytes(password, encoding='utf-8')
+
+    m = hashlib.sha256()
+    m.update(password)
+    hash_pw = m.digest()
+
+    m = hashlib.sha256()
+    m.update(password)
+    m.update(hash_pw)
+    enc_key = m.digest()
+
+    nonce = hash_pw[4:16]
+    aesgcm = AESGCM(enc_key)
+    return aesgcm.encrypt(nonce=nonce,
+                          data=data,
+                          associated_data=b'')
+
+
+def decrypt_bytes(encrypted_bytes, password):
+    """
+    https://cryptography.io/en/latest/hazmat/primitives/aead/
+    :param encrypted_bytes: encrypted data (bytes)
+    :param password: to decrypt the exported bytes
+    :return: decrypted bytes
+    """
+    if isinstance(password, str):
+        password = password.encode('utf-8')
+
+    m = hashlib.sha256()
+    m.update(password)
+    hash_pw = m.digest()
+
+    m = hashlib.sha256()
+    m.update(password)
+    m.update(hash_pw)
+    dec_key = m.digest()
+
+    nonce = hash_pw[4:16]
+    aesgcm = AESGCM(dec_key)
+    dec_value = aesgcm.decrypt(nonce=nonce,
+                               data=encrypted_bytes,
+                               associated_data=b'')
+    return dec_value

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,78 @@
+import aergo.herapy as herapy
+from aergo.herapy.account import Account
+from aergo.herapy.utils.encryption import (
+    encrypt_to_keystore_v1,
+    decrypt_keystore_v1
+)
+from aergo.herapy.utils.converter import (
+    privkey_to_address,
+)
+
+
+keystore = {
+    "kdf": {
+        "algorithm": "scrypt",
+        "mac": "47006a8c1c17f56991ba412a4670da0c373f949ea64918531551e49fed0272ac",
+        "params": {
+            "dklen": 32,
+            "n": 1024,
+            "p": 1,
+            "r": 8,
+            "salt": "f8e0ba7b762bbff83ff7e48af13eedf08ce05fba29d247054139ca620357215f"
+        }
+    },
+    "aergo_address": "AmM8Bspua3d1bACSzCaLUdstjooRLy1YqZ61Kk2nP4VfGTWJzDd6",
+    "ks_version": "1",
+    "cipher": {
+        "algorithm": "aes-128-ctr",
+        "ciphertext": "919b663b4039a9ea88470a6e7138acebb852820100360449e7457171ee003d08",
+        "params": {
+            "iv": "62fc13b3065a22ffd73804e23f47f690"
+        }
+    }
+}
+
+
+def test_account_keystore_v1():
+    # create new account
+    account1 = Account()
+    privkey1 = bytes(account1.private_key)
+    addr1 = bytes(account1.address)
+    # encrypt to keystore
+    keystore = Account.encrypt_to_keystore(account1, 'password', kdf_n=2**10)
+    # decrypt keystore
+    account2 = Account.decrypt_from_keystore(keystore, 'password')
+    privkey2 = bytes(account2.private_key)
+    addr2 = bytes(account2.address)
+    # check the decrypted account is same with original one
+    assert privkey1 == privkey2
+    assert addr1 == addr2
+
+
+def test_decrypt_keystore_v1():
+    # check decrypted address matched the keystore address
+    privkey_raw = decrypt_keystore_v1(keystore, 'password')
+    address = privkey_to_address(privkey_raw)
+    assert address == keystore['aergo_address']
+
+
+def test_encrypt_keystore_v1():
+    account = Account()
+    privkey = bytes(account.private_key)
+    address = str(account.address)
+    new_keystore = encrypt_to_keystore_v1(
+        privkey, address, 'password',  kdf_n=2**10)
+
+    # check keystore format
+    assert keystore['ks_version'] == new_keystore['ks_version']
+    assert keystore['cipher']['algorithm'] == \
+        new_keystore['cipher']['algorithm']
+    assert keystore['kdf']['algorithm'] == new_keystore['kdf']['algorithm']
+
+
+def test_aergo_import_export_account():
+    hera = herapy.Aergo()
+    account = hera.import_account_from_keystore(keystore, 'password', skip_state=True)
+    assert str(account.address) == keystore['aergo_address']
+    new_keystore = hera.export_account_to_keystore('password', kdf_n=2**10)
+    assert new_keystore['aergo_address'] == keystore['aergo_address']


### PR DESCRIPTION
Add support for the new aergo keystore format v1

Follows the same existing structure with: 
- Account.decrypt_from_keystore(), Account.encrypt_to_keystore()
- aergo.import_account_from_keystore(), aergo.export_account_to keystore()

Account encryption related functions are moved to utils.encryption.py